### PR TITLE
Update xls.c

### DIFF
--- a/src/xls.c
+++ b/src/xls.c
@@ -914,9 +914,11 @@ void xls_parseWorkBook(xlsWorkBook* pWB)
 			break;
 		
 		case XLS_RECORD_DEFINEDNAME:
-			printf("DEFINEDNAME: ");
-			for(int i=0; i<bof1.size; ++i) printf("%2.2x ", buf[i]);
-			printf("\n");
+			if(xls_debug) {
+				printf("DEFINEDNAME: ");
+				for(int i=0; i<bof1.size; ++i) printf("%2.2x ", buf[i]);
+				printf("\n");
+			}
 			break;
 			
 #ifdef DEBUG_DRAWINGS


### PR DESCRIPTION
wrap the definedname case in a debug if statement to prevent writing to console when reading from excel files with defined names. 